### PR TITLE
EC2 additions and name corrections

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -254,6 +254,7 @@ type Instance struct {
 
 	// Storage
 	BlockDevices []BlockDevice `xml:"blockDeviceMapping>item"`
+	EbsOptimized bool          `xml:"ebsOptimized"`
 
 	// Network
 	DNSName          string          `xml:"dnsName"`

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -253,6 +253,7 @@ type Instance struct {
 	Monitoring         string              `xml:"monitoring>state"`
 	AvailZone          string              `xml:"placement>availabilityZone"`
 	PlacementGroupName string              `xml:"placement>groupName"`
+	Tenancy            string              `xml:"placement>tenancy"`
 	State              InstanceState       `xml:"instanceState"`
 	StateReason        InstanceStateReason `xml:"stateReason"`
 	Tags               []Tag               `xml:"tagSet>item"`

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -243,18 +243,18 @@ type Instance struct {
 	SecurityGroups   []SecurityGroup `xml:"groupSet>item"`
 	SourceDestCheck  bool            `xml:"sourceDestCheck"`
 
-	KeyName            string        `xml:"keyName"`
-	AMILaunchIndex     int           `xml:"amiLaunchIndex"`
-	Hypervisor         string        `xml:"hypervisor"`
-	VirtType           string        `xml:"virtualizationType"`
-	Monitoring         string        `xml:"monitoring>state"`
-	AvailZone          string        `xml:"placement>availabilityZone"`
-	PlacementGroupName string        `xml:"placement>groupName"`
-	State              InstanceState `xml:"instanceState"`
-	StateReasonCode    string        `xml:"stateReason>code"`
-	Tags               []Tag         `xml:"tagSet>item"`
-	IamInstanceProfile string        `xml:"iamInstanceProfile"`
-	BlockDevices       []BlockDevice `xml:"blockDeviceMapping>item"`
+	KeyName            string              `xml:"keyName"`
+	AMILaunchIndex     int                 `xml:"amiLaunchIndex"`
+	Hypervisor         string              `xml:"hypervisor"`
+	VirtType           string              `xml:"virtualizationType"`
+	Monitoring         string              `xml:"monitoring>state"`
+	AvailZone          string              `xml:"placement>availabilityZone"`
+	PlacementGroupName string              `xml:"placement>groupName"`
+	State              InstanceState       `xml:"instanceState"`
+	StateReason        InstanceStateReason `xml:"stateReason"`
+	Tags               []Tag               `xml:"tagSet>item"`
+	IamInstanceProfile string              `xml:"iamInstanceProfile"`
+	BlockDevices       []BlockDevice       `xml:"blockDeviceMapping>item"`
 }
 
 type BlockDevice struct {
@@ -416,6 +416,14 @@ type InstanceStateChange struct {
 	InstanceId    string        `xml:"instanceId"`
 	CurrentState  InstanceState `xml:"currentState"`
 	PreviousState InstanceState `xml:"previousState"`
+}
+
+// InstanceStateReason describes a state change for an instance in EC2
+//
+// See http://goo.gl/KZkbXi for more details
+type InstanceStateReason struct {
+	Code    string `xml:"code"`
+	Message string `xml:"message"`
 }
 
 // TerminateInstances requests the termination of instances when the given ids.

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -250,6 +250,7 @@ type Instance struct {
 	AvailZone          string        `xml:"placement>availabilityZone"`
 	PlacementGroupName string        `xml:"placement>groupName"`
 	State              InstanceState `xml:"instanceState"`
+	StateReasonCode    string        `xml:"stateReason>code"`
 	Tags               []Tag         `xml:"tagSet>item"`
 	IamInstanceProfile string        `xml:"iamInstanceProfile"`
 	BlockDevices       []BlockDevice `xml:"blockDeviceMapping>item"`

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -272,6 +272,14 @@ type Instance struct {
 	SriovNetSupport   string                     `xml:"sriovNetSupport"`
 }
 
+// isSpotInstance returns if the instance is a spot instance
+func (i Instance) isSpotInstance() bool {
+	if i.InstanceLifecycle == "spot" {
+		return true
+	}
+	return false
+}
+
 type BlockDevice struct {
 	DeviceName string `xml:"deviceName"`
 	EBS        EBS    `xml:"ebs"`

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -240,7 +240,7 @@ type Instance struct {
 	ImageId            string              `xml:"imageId"`
 	KeyName            string              `xml:"keyName"`
 	Monitoring         string              `xml:"monitoring>state"`
-	IamInstanceProfile string              `xml:"iamInstanceProfile"`
+	IamInstanceProfile IamInstanceProfile  `xml:"iamInstanceProfile"`
 
 	// More specific information
 	Architecture          string `xml:"architecture"`          // Valid values: i386 | x86_64
@@ -278,6 +278,13 @@ type EBS struct {
 	Status              string `xml:"status"`
 	AttachTime          string `xml:"attachTime"`
 	DeleteOnTermination bool   `xml:"deleteOnTermination"`
+}
+
+// IamInstanceProfile
+// See http://goo.gl/PjyijL for more details
+type IamInstanceProfile struct {
+	ARN string `xml:"arn"`
+	Id  string `xml:"id"`
 }
 
 // RunInstances starts new instances in EC2.

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -232,6 +232,7 @@ type Instance struct {
 	InstanceId   string `xml:"instanceId"`
 	InstanceType string `xml:"instanceType"`
 	ImageId      string `xml:"imageId"`
+	Architecture string `xml:"architecture"`
 
 	PrivateDNSName   string          `xml:"privateDnsName"`
 	DNSName          string          `xml:"dnsName"`

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -229,15 +229,19 @@ type RunInstancesResp struct {
 //
 // See http://goo.gl/OCH8a for more details.
 type Instance struct {
-	InstanceId         string        `xml:"instanceId"`
-	InstanceType       string        `xml:"instanceType"`
-	ImageId            string        `xml:"imageId"`
-	PrivateDNSName     string        `xml:"privateDnsName"`
-	DNSName            string        `xml:"dnsName"`
-	IPAddress          string        `xml:"ipAddress"`
-	PrivateIPAddress   string        `xml:"privateIpAddress"`
-	SubnetId           string        `xml:"subnetId"`
-	VpcId              string        `xml:"vpcId"`
+	InstanceId   string `xml:"instanceId"`
+	InstanceType string `xml:"instanceType"`
+	ImageId      string `xml:"imageId"`
+
+	PrivateDNSName   string          `xml:"privateDnsName"`
+	DNSName          string          `xml:"dnsName"`
+	IPAddress        string          `xml:"ipAddress"`
+	PrivateIPAddress string          `xml:"privateIpAddress"`
+	SubnetId         string          `xml:"subnetId"`
+	VpcId            string          `xml:"vpcId"`
+	SecurityGroups   []SecurityGroup `xml:"groupSet>item"`
+	SourceDestCheck  bool            `xml:"sourceDestCheck"`
+
 	KeyName            string        `xml:"keyName"`
 	AMILaunchIndex     int           `xml:"amiLaunchIndex"`
 	Hypervisor         string        `xml:"hypervisor"`

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -265,8 +265,11 @@ type Instance struct {
 	SubnetId         string          `xml:"subnetId"`
 	VpcId            string          `xml:"vpcId"`
 	SecurityGroups   []SecurityGroup `xml:"groupSet>item"`
-	SourceDestCheck  bool            `xml:"sourceDestCheck"`
-	SriovNetSupport  string          `xml:"sriovNetSupport"`
+
+	// Advanced Networking
+	NetworkInterfaces []InstanceNetworkInterface `xml:"networkInterfaceSet>item"`
+	SourceDestCheck   bool                       `xml:"sourceDestCheck"`
+	SriovNetSupport   string                     `xml:"sriovNetSupport"`
 }
 
 type BlockDevice struct {
@@ -279,6 +282,52 @@ type EBS struct {
 	Status              string `xml:"status"`
 	AttachTime          string `xml:"attachTime"`
 	DeleteOnTermination bool   `xml:"deleteOnTermination"`
+}
+
+// InstanceNetworkInterface represents a network interface attached to an instance
+// See http://goo.gl/9eW02N for more details.
+type InstanceNetworkInterface struct {
+	Id                 string                              `xml:"networkInterfaceId"`
+	Description        string                              `xml:"description"`
+	SubnetId           string                              `xml:"subnetId"`
+	VpcId              string                              `xml:"vpcId"`
+	OwnerId            string                              `xml:"ownerId"` // The ID of the AWS account that created the network interface.
+	Status             string                              `xml:"status"`  // Valid values: available | attaching | in-use | detaching
+	MacAddress         string                              `xml:"macAddress"`
+	PrivateIPAddress   string                              `xml:"privateIpAddress"`
+	PrivateDNSName     string                              `xml:"privateDnsName"`
+	SourceDestCheck    bool                                `xml:"sourceDestCheck"`
+	SecurityGroups     []SecurityGroup                     `xml:"groupSet>item"`
+	Attachment         InstanceNetworkInterfaceAttachment  `xml:"attachment"`
+	Association        InstanceNetworkInterfaceAssociation `xml:"association"`
+	PrivateIPAddresses []InstancePrivateIpAddress          `xml:"privateIpAddressesSet>item"`
+}
+
+// InstanceNetworkInterfaceAttachment describes a network interface attachment to an instance
+// See http://goo.gl/0ql0Cg for more details
+type InstanceNetworkInterfaceAttachment struct {
+	AttachmentID        string `xml:"attachmentID"`        // The ID of the network interface attachment.
+	DeviceIndex         int32  `xml:"deviceIndex"`         // The index of the device on the instance for the network interface attachment.
+	Status              string `xml:"status"`              // Valid values: attaching | attached | detaching | detached
+	AttachTime          string `xml:"attachTime"`          // Time attached, as a Datetime
+	DeleteOnTermination bool   `xml:"deleteOnTermination"` // Indicates whether the network interface is deleted when the instance is terminated.
+}
+
+// Describes association information for an Elastic IP address.
+// See http://goo.gl/YCDdMe for more details
+type InstanceNetworkInterfaceAssociation struct {
+	PublicIP      string `xml:"publicIp"`      // The address of the Elastic IP address bound to the network interface
+	PublicDNSName string `xml:"publicDnsName"` // The public DNS name
+	IPOwnerId     string `xml:"ipOwnerId"`     // The ID of the owner of the Elastic IP address
+}
+
+// InstancePrivateIpAddress describes a private IP address
+// See http://goo.gl/irN646 for more details
+type InstancePrivateIpAddress struct {
+	PrivateIPAddress string                              `xml:"privateIpAddress"` // The private IP address of the network interface
+	PrivateDNSName   string                              `xml:"privateDnsName"`   // The private DNS name
+	Primary          bool                                `xml:"primary"`          // Indicates whether this IP address is the primary private IP address of the network interface
+	Association      InstanceNetworkInterfaceAssociation `xml:"association"`      // The association information for an Elastic IP address for the network interface
 }
 
 // IamInstanceProfile

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -236,6 +236,8 @@ type Instance struct {
 	DNSName            string        `xml:"dnsName"`
 	IPAddress          string        `xml:"ipAddress"`
 	PrivateIPAddress   string        `xml:"privateIpAddress"`
+	SubnetId           string        `xml:"subnetId"`
+	VpcId              string        `xml:"vpcId"`
 	KeyName            string        `xml:"keyName"`
 	AMILaunchIndex     int           `xml:"amiLaunchIndex"`
 	Hypervisor         string        `xml:"hypervisor"`

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -229,15 +229,35 @@ type RunInstancesResp struct {
 //
 // See http://goo.gl/OCH8a for more details.
 type Instance struct {
-	InstanceId            string `xml:"instanceId"`
-	InstanceType          string `xml:"instanceType"`
-	ImageId               string `xml:"imageId"`
-	Architecture          string `xml:"architecture"`
-	InstanceLifecycle     string `xml:"instanceLifecycle"`
-	SpotInstanceRequestId string `xml:"spotInstanceRequestId"`
 
-	PrivateDNSName   string          `xml:"privateDnsName"`
+	// General instance information
+	InstanceId         string              `xml:"instanceId"`
+	InstanceType       string              `xml:"instanceType"`
+	AvailZone          string              `xml:"placement>availabilityZone"`
+	Tags               []Tag               `xml:"tagSet>item"`
+	State              InstanceState       `xml:"instanceState"`
+	StateReason        InstanceStateReason `xml:"stateReason"`
+	ImageId            string              `xml:"imageId"`
+	KeyName            string              `xml:"keyName"`
+	Monitoring         string              `xml:"monitoring>state"`
+	IamInstanceProfile string              `xml:"iamInstanceProfile"`
+
+	// More specific information
+	Architecture          string `xml:"architecture"`          // Valid values: i386 | x86_64
+	Hypervisor            string `xml:"hypervisor"`            // Valid values: ovm | xen
+	VirtType              string `xml:"virtualizationType"`    // Valid values: paravirtual | hvm
+	AMILaunchIndex        int    `xml:"amiLaunchIndex"`        // The AMI launch index, which can be used to find this instance in the launch group.
+	PlacementGroupName    string `xml:"placement>groupName"`   // The name of the placement group the instance is in (for cluster compute instances)
+	Tenancy               string `xml:"placement>tenancy"`     // (VPC only) Valid values: default | dedicated
+	InstanceLifecycle     string `xml:"instanceLifecycle"`     // Spot instance? Valid values: "spot" or blank
+	SpotInstanceRequestId string `xml:"spotInstanceRequestId"` // The ID of the Spot Instance request
+
+	// Storage
+	BlockDevices []BlockDevice `xml:"blockDeviceMapping>item"`
+
+	// Network
 	DNSName          string          `xml:"dnsName"`
+	PrivateDNSName   string          `xml:"privateDnsName"`
 	IPAddress        string          `xml:"ipAddress"`
 	PrivateIPAddress string          `xml:"privateIpAddress"`
 	SubnetId         string          `xml:"subnetId"`
@@ -245,20 +265,6 @@ type Instance struct {
 	SecurityGroups   []SecurityGroup `xml:"groupSet>item"`
 	SourceDestCheck  bool            `xml:"sourceDestCheck"`
 	SriovNetSupport  string          `xml:"sriovNetSupport"`
-
-	KeyName            string              `xml:"keyName"`
-	AMILaunchIndex     int                 `xml:"amiLaunchIndex"`
-	Hypervisor         string              `xml:"hypervisor"`
-	VirtType           string              `xml:"virtualizationType"`
-	Monitoring         string              `xml:"monitoring>state"`
-	AvailZone          string              `xml:"placement>availabilityZone"`
-	PlacementGroupName string              `xml:"placement>groupName"`
-	Tenancy            string              `xml:"placement>tenancy"`
-	State              InstanceState       `xml:"instanceState"`
-	StateReason        InstanceStateReason `xml:"stateReason"`
-	Tags               []Tag               `xml:"tagSet>item"`
-	IamInstanceProfile string              `xml:"iamInstanceProfile"`
-	BlockDevices       []BlockDevice       `xml:"blockDeviceMapping>item"`
 }
 
 type BlockDevice struct {

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -241,6 +241,7 @@ type Instance struct {
 	KeyName            string              `xml:"keyName"`
 	Monitoring         string              `xml:"monitoring>state"`
 	IamInstanceProfile IamInstanceProfile  `xml:"iamInstanceProfile"`
+	LaunchTime         string              `xml:"launchTime"`
 
 	// More specific information
 	Architecture          string `xml:"architecture"`          // Valid values: i386 | x86_64

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -229,10 +229,12 @@ type RunInstancesResp struct {
 //
 // See http://goo.gl/OCH8a for more details.
 type Instance struct {
-	InstanceId   string `xml:"instanceId"`
-	InstanceType string `xml:"instanceType"`
-	ImageId      string `xml:"imageId"`
-	Architecture string `xml:"architecture"`
+	InstanceId            string `xml:"instanceId"`
+	InstanceType          string `xml:"instanceType"`
+	ImageId               string `xml:"imageId"`
+	Architecture          string `xml:"architecture"`
+	InstanceLifecycle     string `xml:"instanceLifecycle"`
+	SpotInstanceRequestId string `xml:"spotInstanceRequestId"`
 
 	PrivateDNSName   string          `xml:"privateDnsName"`
 	DNSName          string          `xml:"dnsName"`

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -242,6 +242,7 @@ type Instance struct {
 	VpcId            string          `xml:"vpcId"`
 	SecurityGroups   []SecurityGroup `xml:"groupSet>item"`
 	SourceDestCheck  bool            `xml:"sourceDestCheck"`
+	SriovNetSupport  string          `xml:"sriovNetSupport"`
 
 	KeyName            string              `xml:"keyName"`
 	AMILaunchIndex     int                 `xml:"amiLaunchIndex"`

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -233,7 +233,7 @@ type Instance struct {
 	// General instance information
 	InstanceId         string              `xml:"instanceId"`
 	InstanceType       string              `xml:"instanceType"`
-	AvailZone          string              `xml:"placement>availabilityZone"`
+	AvailabilityZone   string              `xml:"placement>availabilityZone"`
 	Tags               []Tag               `xml:"tagSet>item"`
 	State              InstanceState       `xml:"instanceState"`
 	StateReason        InstanceStateReason `xml:"stateReason"`
@@ -245,7 +245,7 @@ type Instance struct {
 	// More specific information
 	Architecture          string `xml:"architecture"`          // Valid values: i386 | x86_64
 	Hypervisor            string `xml:"hypervisor"`            // Valid values: ovm | xen
-	VirtType              string `xml:"virtualizationType"`    // Valid values: paravirtual | hvm
+	VirtualizationType    string `xml:"virtualizationType"`    // Valid values: paravirtual | hvm
 	AMILaunchIndex        int    `xml:"amiLaunchIndex"`        // The AMI launch index, which can be used to find this instance in the launch group.
 	PlacementGroupName    string `xml:"placement>groupName"`   // The name of the placement group the instance is in (for cluster compute instances)
 	Tenancy               string `xml:"placement>tenancy"`     // (VPC only) Valid values: default | dedicated

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -202,7 +202,7 @@ type RunInstancesOptions struct {
 	KernelId               string
 	RamdiskId              string
 	UserData               []byte
-	AvailZone              string
+	AvailabilityZone       string
 	PlacementGroupName     string
 	Monitoring             bool
 	SubnetId               string
@@ -423,8 +423,8 @@ func (ec2 *EC2) RunInstances(options *RunInstancesOptions) (resp *RunInstancesRe
 		b64.Encode(userData, options.UserData)
 		params["UserData"] = string(userData)
 	}
-	if options.AvailZone != "" {
-		params["Placement.AvailabilityZone"] = options.AvailZone
+	if options.AvailabilityZone != "" {
+		params["Placement.AvailabilityZone"] = options.AvailabilityZone
 	}
 	if options.PlacementGroupName != "" {
 		params["Placement.GroupName"] = options.PlacementGroupName

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -250,15 +250,15 @@ type Instance struct {
 }
 
 type BlockDevice struct {
-	DeviceName         string        `xml:"deviceName"`
-	EBS EBS `xml:"ebs"`
+	DeviceName string `xml:"deviceName"`
+	EBS        EBS    `xml:"ebs"`
 }
 
 type EBS struct {
-	VolumeId string `xml:"volumeId"`
-	Status string `xml:"status"`
-	AttachTime string `xml:"attachTime"`
-	DeleteOnTermination bool `xml:"deleteOnTermination"`
+	VolumeId            string `xml:"volumeId"`
+	Status              string `xml:"status"`
+	AttachTime          string `xml:"attachTime"`
+	DeleteOnTermination bool   `xml:"deleteOnTermination"`
 }
 
 // RunInstances starts new instances in EC2.

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -713,7 +713,7 @@ type Reservation struct {
 // matching the given instance ids or filtering rules.
 //
 // See http://goo.gl/4No7c for more details.
-func (ec2 *EC2) Instances(instIds []string, filter *Filter) (resp *InstancesResp, err error) {
+func (ec2 *EC2) DescribeInstances(instIds []string, filter *Filter) (resp *InstancesResp, err error) {
 	params := makeParams("DescribeInstances")
 	addParamsList(params, "InstanceId", instIds)
 	filter.addParams(params)

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -242,6 +242,7 @@ type Instance struct {
 	Monitoring         string              `xml:"monitoring>state"`
 	IamInstanceProfile IamInstanceProfile  `xml:"iamInstanceProfile"`
 	LaunchTime         string              `xml:"launchTime"`
+	OwnerId            string              // This isn't currently returned in the response, and is taken from the parent reservation
 
 	// More specific information
 	Architecture          string `xml:"architecture"`          // Valid values: i386 | x86_64
@@ -722,6 +723,16 @@ func (ec2 *EC2) DescribeInstances(instIds []string, filter *Filter) (resp *Insta
 	if err != nil {
 		return nil, err
 	}
+
+	// Add additional parameters to instances which aren't available in the response
+	for i, rsv := range resp.Reservations {
+		ownerId := rsv.OwnerId
+		for j, inst := range rsv.Instances {
+			inst.OwnerId = ownerId
+			resp.Reservations[i].Instances[j] = inst
+		}
+	}
+
 	return
 }
 

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -85,7 +85,7 @@ func (s *S) TestRunInstancesExample(c *gocheck.C) {
 		UserData:              []byte("1234"),
 		KernelId:              "kernel-id",
 		RamdiskId:             "ramdisk-id",
-		AvailZone:             "zone",
+		AvailabilityZone:      "zone",
 		PlacementGroupName:    "group",
 		Monitoring:            true,
 		SubnetId:              "subnet-id",
@@ -131,7 +131,7 @@ func (s *S) TestRunInstancesExample(c *gocheck.C) {
 	c.Assert(i0.Monitoring, gocheck.Equals, "enabled")
 	c.Assert(i0.KeyName, gocheck.Equals, "example-key-name")
 	c.Assert(i0.AMILaunchIndex, gocheck.Equals, 0)
-	c.Assert(i0.VirtType, gocheck.Equals, "paravirtual")
+	c.Assert(i0.VirtualizationType, gocheck.Equals, "paravirtual")
 	c.Assert(i0.Hypervisor, gocheck.Equals, "xen")
 
 	i1 := resp.Instances[1]
@@ -141,7 +141,7 @@ func (s *S) TestRunInstancesExample(c *gocheck.C) {
 	c.Assert(i1.Monitoring, gocheck.Equals, "enabled")
 	c.Assert(i1.KeyName, gocheck.Equals, "example-key-name")
 	c.Assert(i1.AMILaunchIndex, gocheck.Equals, 1)
-	c.Assert(i1.VirtType, gocheck.Equals, "paravirtual")
+	c.Assert(i1.VirtualizationType, gocheck.Equals, "paravirtual")
 	c.Assert(i1.Hypervisor, gocheck.Equals, "xen")
 
 	i2 := resp.Instances[2]
@@ -151,7 +151,7 @@ func (s *S) TestRunInstancesExample(c *gocheck.C) {
 	c.Assert(i2.Monitoring, gocheck.Equals, "enabled")
 	c.Assert(i2.KeyName, gocheck.Equals, "example-key-name")
 	c.Assert(i2.AMILaunchIndex, gocheck.Equals, 2)
-	c.Assert(i2.VirtType, gocheck.Equals, "paravirtual")
+	c.Assert(i2.VirtualizationType, gocheck.Equals, "paravirtual")
 	c.Assert(i2.Hypervisor, gocheck.Equals, "xen")
 }
 
@@ -214,7 +214,7 @@ func (s *S) TestDescribeInstancesExample1(c *gocheck.C) {
 	c.Assert(r0i.InstanceId, gocheck.Equals, "i-c5cd56af")
 	c.Assert(r0i.PrivateDNSName, gocheck.Equals, "domU-12-31-39-10-56-34.compute-1.internal")
 	c.Assert(r0i.DNSName, gocheck.Equals, "ec2-174-129-165-232.compute-1.amazonaws.com")
-	c.Assert(r0i.AvailZone, gocheck.Equals, "us-east-1b")
+	c.Assert(r0i.AvailabilityZone, gocheck.Equals, "us-east-1b")
 	c.Assert(r0i.IPAddress, gocheck.Equals, "174.129.165.232")
 	c.Assert(r0i.PrivateIPAddress, gocheck.Equals, "10.198.85.190")
 }

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -192,7 +192,7 @@ func (s *S) TestDescribeInstancesExample1(c *gocheck.C) {
 	filter.Add("key1", "value1")
 	filter.Add("key2", "value2", "value3")
 
-	resp, err := s.ec2.Instances([]string{"i-1", "i-2"}, nil)
+	resp, err := s.ec2.DescribeInstances([]string{"i-1", "i-2"}, nil)
 
 	req := testServer.WaitRequest()
 	c.Assert(req.Form["Action"], gocheck.DeepEquals, []string{"DescribeInstances"})
@@ -226,7 +226,7 @@ func (s *S) TestDescribeInstancesExample2(c *gocheck.C) {
 	filter.Add("key1", "value1")
 	filter.Add("key2", "value2", "value3")
 
-	resp, err := s.ec2.Instances([]string{"i-1", "i-2"}, filter)
+	resp, err := s.ec2.DescribeInstances([]string{"i-1", "i-2"}, filter)
 
 	req := testServer.WaitRequest()
 	c.Assert(req.Form["Action"], gocheck.DeepEquals, []string{"DescribeInstances"})

--- a/ec2/ec2i_test.go
+++ b/ec2/ec2i_test.go
@@ -83,7 +83,7 @@ func (s *ClientTests) TestRunAndTerminate(c *gocheck.C) {
 
 	instId := resp1.Instances[0].InstanceId
 
-	resp2, err := s.ec2.Instances([]string{instId}, nil)
+	resp2, err := s.ec2.DescribeInstances([]string{instId}, nil)
 	c.Assert(err, gocheck.IsNil)
 	if c.Check(resp2.Reservations, gocheck.HasLen, 1) && c.Check(len(resp2.Reservations[0].Instances), gocheck.Equals, 1) {
 		inst := resp2.Reservations[0].Instances[0]

--- a/ec2/ec2t_test.go
+++ b/ec2/ec2t_test.go
@@ -397,7 +397,7 @@ func (s *ServerTests) TestInstanceFiltering(c *gocheck.C) {
 				f.Add(spec.name, spec.values...)
 			}
 		}
-		resp, err := s.ec2.Instances(t.instanceIds, f)
+		resp, err := s.ec2.DescribeInstances(t.instanceIds, f)
 		if t.err != "" {
 			c.Check(err, gocheck.ErrorMatches, t.err)
 			continue

--- a/ec2/ec2test/server.go
+++ b/ec2/ec2test/server.go
@@ -422,7 +422,7 @@ func (srv *Server) runInstances(w http.ResponseWriter, req *http.Request, reqId 
 	//    InstanceType              ?
 	//    KernelId                  ?
 	//    RamdiskId                 ?
-	//    AvailZone                 ?
+	//    AvailabilityZone          ?
 	//    GroupName                 tag
 	//    Monitoring                ignore?
 	//    SubnetId                  ?

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -25,12 +25,12 @@ func New(auth aws.Auth, region aws.Region) *ELB {
 //
 // See http://goo.gl/4QFKi for more details.
 type CreateLoadBalancer struct {
-	Name           string
-	AvailZones     []string
-	Listeners      []Listener
-	Scheme         string
-	SecurityGroups []string
-	Subnets        []string
+	Name              string
+	AvailabilityZones []string
+	Listeners         []Listener
+	Scheme            string
+	SecurityGroups    []string
+	Subnets           []string
 }
 
 // Listener to configure in Load Balancer.
@@ -131,7 +131,7 @@ type DescribeLoadBalancerResp struct {
 }
 
 type LoadBalancerDescription struct {
-	AvailZones                []string                    `xml:"AvailabilityZones>member"`
+	AvailabilityZones         []string                    `xml:"AvailabilityZones>member"`
 	BackendServerDescriptions []BackendServerDescriptions `xml:"BackendServerDescriptions>member"`
 	CanonicalHostedZoneName   string                      `xml:"CanonicalHostedZoneName"`
 	CanonicalHostedZoneNameId string                      `xml:"CanonicalHostedZoneNameID"`
@@ -360,7 +360,7 @@ func makeCreateParams(createLB *CreateLoadBalancer) map[string]string {
 		params[fmt.Sprintf(key, index, "Protocol")] = l.Protocol
 		params[fmt.Sprintf(key, index, "LoadBalancerPort")] = strconv.Itoa(l.LoadBalancerPort)
 	}
-	for i, az := range createLB.AvailZones {
+	for i, az := range createLB.AvailabilityZones {
 		key := fmt.Sprintf("AvailabilityZones.member.%d", i+1)
 		params[key] = az
 	}

--- a/elb/elb_test.go
+++ b/elb/elb_test.go
@@ -23,8 +23,8 @@ func (s *S) SetUpSuite(c *gocheck.C) {
 func (s *S) TestCreateLoadBalancer(c *gocheck.C) {
 	testServer.PrepareResponse(200, nil, CreateLoadBalancer)
 	createLB := &elb.CreateLoadBalancer{
-		Name:       "testlb",
-		AvailZones: []string{"us-east-1a", "us-east-1b"},
+		Name:              "testlb",
+		AvailabilityZones: []string{"us-east-1a", "us-east-1b"},
 		Listeners: []elb.Listener{
 			{
 				InstancePort:     80,
@@ -90,8 +90,8 @@ func (s *S) TestCreateLoadBalancerWithSubnetsAndMoreListeners(c *gocheck.C) {
 func (s *S) TestCreateLoadBalancerWithWrongParamsCombination(c *gocheck.C) {
 	testServer.PrepareResponse(400, nil, CreateLoadBalancerBadRequest)
 	createLB := &elb.CreateLoadBalancer{
-		Name:       "testlb",
-		AvailZones: []string{"us-east-1a", "us-east-1b"},
+		Name:              "testlb",
+		AvailabilityZones: []string{"us-east-1a", "us-east-1b"},
 		Listeners: []elb.Listener{
 			{
 				InstancePort:     80,
@@ -189,7 +189,7 @@ func (s *S) TestDescribeLoadBalancers(c *gocheck.C) {
 	expected := &elb.DescribeLoadBalancerResp{
 		[]elb.LoadBalancerDescription{
 			{
-				AvailZones:                []string{"us-east-1a"},
+				AvailabilityZones:         []string{"us-east-1a"},
 				BackendServerDescriptions: []elb.BackendServerDescriptions(nil),
 				CanonicalHostedZoneName:   "testlb-2087227216.us-east-1.elb.amazonaws.com",
 				CanonicalHostedZoneNameId: "Z3DZXE0Q79N41H",

--- a/elb/elbi_test.go
+++ b/elb/elbi_test.go
@@ -50,8 +50,8 @@ func (s *AmazonClientSuite) SetUpSuite(c *gocheck.C) {
 
 func (s *ClientTests) TestCreateAndDeleteLoadBalancer(c *gocheck.C) {
 	createLBReq := elb.CreateLoadBalancer{
-		Name:       "testlb",
-		AvailZones: []string{"us-east-1a"},
+		Name:              "testlb",
+		AvailabilityZones: []string{"us-east-1a"},
 		Listeners: []elb.Listener{
 			{
 				InstancePort:     80,
@@ -72,9 +72,9 @@ func (s *ClientTests) TestCreateAndDeleteLoadBalancer(c *gocheck.C) {
 
 func (s *ClientTests) TestCreateLoadBalancerError(c *gocheck.C) {
 	createLBReq := elb.CreateLoadBalancer{
-		Name:       "testlb",
-		AvailZones: []string{"us-east-1a"},
-		Subnets:    []string{"subnetid-1"},
+		Name:              "testlb",
+		AvailabilityZones: []string{"us-east-1a"},
+		Subnets:           []string{"subnetid-1"},
 		Listeners: []elb.Listener{
 			{
 				InstancePort:     80,
@@ -95,16 +95,16 @@ func (s *ClientTests) TestCreateLoadBalancerError(c *gocheck.C) {
 
 func (s *ClientTests) createInstanceAndLB(c *gocheck.C) (*elb.CreateLoadBalancer, string) {
 	options := ec2.RunInstancesOptions{
-		ImageId:      "ami-ccf405a5",
-		InstanceType: "t1.micro",
-		AvailZone:    "us-east-1c",
+		ImageId:          "ami-ccf405a5",
+		InstanceType:     "t1.micro",
+		AvailabilityZone: "us-east-1c",
 	}
 	resp1, err := s.ec2.RunInstances(&options)
 	c.Assert(err, gocheck.IsNil)
 	instId := resp1.Instances[0].InstanceId
 	createLBReq := elb.CreateLoadBalancer{
-		Name:       "testlb",
-		AvailZones: []string{"us-east-1c"},
+		Name:              "testlb",
+		AvailabilityZones: []string{"us-east-1c"},
 		Listeners: []elb.Listener{
 			{
 				InstancePort:     80,
@@ -138,8 +138,8 @@ func (s *ClientTests) TestCreateRegisterAndDeregisterInstanceWithLoadBalancer(c 
 
 func (s *ClientTests) TestDescribeLoadBalancers(c *gocheck.C) {
 	createLBReq := elb.CreateLoadBalancer{
-		Name:       "testlb",
-		AvailZones: []string{"us-east-1a"},
+		Name:              "testlb",
+		AvailabilityZones: []string{"us-east-1a"},
 		Listeners: []elb.Listener{
 			{
 				InstancePort:     80,
@@ -158,7 +158,7 @@ func (s *ClientTests) TestDescribeLoadBalancers(c *gocheck.C) {
 	resp, err := s.elb.DescribeLoadBalancers()
 	c.Assert(err, gocheck.IsNil)
 	c.Assert(len(resp.LoadBalancerDescriptions) > 0, gocheck.Equals, true)
-	c.Assert(resp.LoadBalancerDescriptions[0].AvailZones, gocheck.DeepEquals, []string{"us-east-1a"})
+	c.Assert(resp.LoadBalancerDescriptions[0].AvailabilityZones, gocheck.DeepEquals, []string{"us-east-1a"})
 	c.Assert(resp.LoadBalancerDescriptions[0].LoadBalancerName, gocheck.Equals, "testlb")
 	c.Assert(resp.LoadBalancerDescriptions[0].Scheme, gocheck.Equals, "internet-facing")
 	hc := elb.HealthCheck{
@@ -215,8 +215,8 @@ func (s *ClientTests) TestDescribeInstanceHealth(c *gocheck.C) {
 
 func (s *ClientTests) TestDescribeInstanceHealthBadRequest(c *gocheck.C) {
 	createLBReq := elb.CreateLoadBalancer{
-		Name:       "testlb",
-		AvailZones: []string{"us-east-1a"},
+		Name:              "testlb",
+		AvailabilityZones: []string{"us-east-1a"},
 		Listeners: []elb.Listener{
 			{
 				InstancePort:     80,
@@ -240,8 +240,8 @@ func (s *ClientTests) TestDescribeInstanceHealthBadRequest(c *gocheck.C) {
 
 func (s *ClientTests) TestConfigureHealthCheck(c *gocheck.C) {
 	createLBReq := elb.CreateLoadBalancer{
-		Name:       "testlb",
-		AvailZones: []string{"us-east-1a"},
+		Name:              "testlb",
+		AvailabilityZones: []string{"us-east-1a"},
 		Listeners: []elb.Listener{
 			{
 				InstancePort:     80,
@@ -275,8 +275,8 @@ func (s *ClientTests) TestConfigureHealthCheck(c *gocheck.C) {
 
 func (s *ClientTests) TestConfigureHealthCheckBadRequest(c *gocheck.C) {
 	createLBReq := elb.CreateLoadBalancer{
-		Name:       "testlb",
-		AvailZones: []string{"us-east-1a"},
+		Name:              "testlb",
+		AvailabilityZones: []string{"us-east-1a"},
 		Listeners: []elb.Listener{
 			{
 				InstancePort:     80,

--- a/elb/elbtest/server.go
+++ b/elb/elbtest/server.go
@@ -286,7 +286,7 @@ func (srv *Server) makeLoadBalancerDescription(value url.Values) *elb.LoadBalanc
 	}
 	sourceSecGroup := srv.makeSourceSecGroup(value)
 	lbDesc := elb.LoadBalancerDescription{
-		AvailZones:           srv.getParameters("AvailabilityZones.member.", value),
+		AvailabilityZones:    srv.getParameters("AvailabilityZones.member.", value),
 		Subnets:              srv.getParameters("Subnets.member.", value),
 		SecurityGroups:       srv.getParameters("SecurityGroups.member.", value),
 		HealthCheck:          srv.makeHealthCheck(value),


### PR DESCRIPTION
Updates `ec2` with additional parameters on the structs, and make these match the Amazon API rather than having custom names for fields and methods.

Backwards incompatible changes:
`ec2.Instances` method (which called _DescribeInstances_) called `ec2.DescribeInstances`
`ec2.Instance.AvailZone` now called `AvailabilityZone`
`ec2.Instance.VirtType` now called `VirtualizationType`
`ec2.Instance.IamInstanceProfile` is now of type `IamInstanceProfile` rather than `string`

Basic additions to `ec2.Instance` type:

``` go
StateReason           InstanceStateReason
EbsOptimized          bool
LaunchTime            string
OwnerId               string
Architecture          string
Tenancy               string
SecurityGroups        []SecurityGroup
```

Also methods for spot instance types:

``` go
InstanceLifecycle     string
SpotInstanceRequestId string

func (i Instance) isSpotInstance() bool {}
```

Added more advanced networking information which lists network interfaces, attachments, private IP assignments, and elastic IP attachments:

``` go
NetworkInterfaces []InstanceNetworkInterface
SourceDestCheck   bool
SriovNetSupport   string
```
