### PR TITLE
PutCopyFrom method used to copy directly in s3

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -313,6 +313,32 @@ func (b *Bucket) PutReader(path string, r io.Reader, length int64, contType stri
 	return b.S3.query(req, nil)
 }
 
+func (b *Bucket) PutCopyFrom(rsp interface{}, path string, from string, perm ACL, options Options) error {
+	fmt.Printf("%+v", path)
+	headers := map[string][]string{
+		"x-amz-acl": {string(perm)},
+	}
+	if options.SSE {
+		headers["x-amz-server-side-encryption"] = []string{"AES256"}
+	}
+
+	for k, v := range options.Meta {
+		headers["x-amz-meta-"+k] = v
+	}
+
+	headers["x-amz-copy-source"] = []string{from}
+
+	req := &request{
+		method:  "PUT",
+		bucket:  b.Name,
+		path:    path,
+		headers: headers,
+		payload: nil,
+	}
+	fmt.Printf("REQ: %+v", req)
+	return b.S3.query(req, rsp)
+}
+
 type RoutingRule struct {
 	ConditionKeyPrefixEquals     string `xml:"Condition>KeyPrefixEquals"`
 	RedirectReplaceKeyPrefixWith string `xml:"Redirect>ReplaceKeyPrefixWith,omitempty"`

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -789,7 +789,7 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 
 	if err != nil {
 
-		if hresp != nil && hresp.Body != nil {
+		if hresp.Body != nil {
 			hresp.Body.Close()
 		}
 

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -785,8 +785,6 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 	}
 
 	hresp, err := c.Do(&hreq)
-	defer hresp.Body.Close()
-
 	if err != nil {
 		return nil, err
 	}
@@ -799,12 +797,13 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 	}
 	if resp != nil {
 		err = xml.NewDecoder(hresp.Body).Decode(resp)
+		hresp.Body.Close()
 
 		if debug {
 			log.Printf("goamz.s3> decoded xml into %#v", resp)
 		}
-	}
 
+	}
 	return hresp, err
 }
 

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -789,7 +789,7 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 
 	if err != nil {
 
-		if hresp.Body != nil {
+		if hresp != nil && hresp.Body != nil {
 			hresp.Body.Close()
 		}
 

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -339,10 +339,7 @@ func (b *Bucket) PutCopyFrom(path string, from string, perm ACL, options Options
 		payload: nil,
 	}
 
-	resp, err := b.S3.rspquery(req, nil)
-	if resp != nil && resp.Body != nil {
-		resp.Body.Close()
-	}
+	err := b.S3.query(req, nil)
 	return err
 }
 
@@ -675,14 +672,6 @@ func (s3 *S3) query(req *request, resp interface{}) error {
 		_, err = s3.run(req, resp)
 	}
 	return err
-}
-
-func (s3 *S3) rspquery(req *request, resp interface{}) (*http.Response, error) {
-	err := s3.prepare(req)
-	if err == nil {
-		return s3.run(req, resp)
-	}
-	return nil, err
 }
 
 // prepare sets up req to be delivered to S3.

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -313,8 +313,11 @@ func (b *Bucket) PutReader(path string, r io.Reader, length int64, contType stri
 	return b.S3.query(req, nil)
 }
 
+/*
+	This function allows you to copy a file from one location to another.
+	The original source file will not be deleted.
+*/
 func (b *Bucket) PutCopyFrom(path string, from string, perm ACL, options Options) (resp *http.Response, err error) {
-	fmt.Printf("%+v", path)
 	headers := map[string][]string{
 		"x-amz-acl": {string(perm)},
 	}
@@ -336,7 +339,11 @@ func (b *Bucket) PutCopyFrom(path string, from string, perm ACL, options Options
 		payload: nil,
 	}
 
-	return b.S3.rspquery(req, nil)
+	err = b.S3.prepare(req)
+	if err == nil {
+		return b.S3.run(req, nil)
+	}
+	return nil, err
 }
 
 type RoutingRule struct {
@@ -668,14 +675,6 @@ func (s3 *S3) query(req *request, resp interface{}) error {
 		_, err = s3.run(req, resp)
 	}
 	return err
-}
-
-func (s3 *S3) rspquery(req *request, resp interface{}) (*http.Response, error) {
-	err := s3.prepare(req)
-	if err == nil {
-		return s3.run(req, resp)
-	}
-	return nil, err
 }
 
 // prepare sets up req to be delivered to S3.

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -786,9 +786,13 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 	}
 
 	hresp, err := c.Do(&hreq)
-	defer hresp.Body.Close()
 
 	if err != nil {
+
+		if hresp.Body != nil {
+			hresp.Body.Close()
+		}
+
 		return nil, err
 	}
 	if debug {
@@ -804,6 +808,11 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 		if debug {
 			log.Printf("goamz.s3> decoded xml into %#v", resp)
 		}
+
+	}
+
+	if hresp.Body != nil {
+		hresp.Body.Close()
 	}
 
 	return hresp, err

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -786,6 +786,8 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 	}
 
 	hresp, err := c.Do(&hreq)
+	defer hresp.Body.Close()
+
 	if err != nil {
 		return nil, err
 	}
@@ -798,13 +800,12 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 	}
 	if resp != nil {
 		err = xml.NewDecoder(hresp.Body).Decode(resp)
-		hresp.Body.Close()
 
 		if debug {
 			log.Printf("goamz.s3> decoded xml into %#v", resp)
 		}
-
 	}
+
 	return hresp, err
 }
 

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -313,6 +313,32 @@ func (b *Bucket) PutReader(path string, r io.Reader, length int64, contType stri
 	return b.S3.query(req, nil)
 }
 
+func (b *Bucket) PutCopyFrom(path string, from string, perm ACL, options Options) error {
+	fmt.Printf("%+v", path)
+	headers := map[string][]string{
+		"x-amz-acl": {string(perm)},
+	}
+	if options.SSE {
+		headers["x-amz-server-side-encryption"] = []string{"AES256"}
+	}
+
+	for k, v := range options.Meta {
+		headers["x-amz-meta-"+k] = v
+	}
+
+	headers["x-amz-copy-source"] = []string{from}
+
+	req := &request{
+		method:  "PUT",
+		bucket:  b.Name,
+		path:    path,
+		headers: headers,
+		payload: nil,
+	}
+	fmt.Printf("REQ: %+v", req)
+	return b.S3.query(req, nil)
+}
+
 type RoutingRule struct {
 	ConditionKeyPrefixEquals     string `xml:"Condition>KeyPrefixEquals"`
 	RedirectReplaceKeyPrefixWith string `xml:"Redirect>ReplaceKeyPrefixWith,omitempty"`

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -313,7 +313,7 @@ func (b *Bucket) PutReader(path string, r io.Reader, length int64, contType stri
 	return b.S3.query(req, nil)
 }
 
-func (b *Bucket) PutCopyFrom(rsp interface{}, path string, from string, perm ACL, options Options) error {
+func (b *Bucket) PutCopyFrom(path string, from string, perm ACL, options Options) (resp *http.Response, err error) {
 	fmt.Printf("%+v", path)
 	headers := map[string][]string{
 		"x-amz-acl": {string(perm)},
@@ -335,8 +335,8 @@ func (b *Bucket) PutCopyFrom(rsp interface{}, path string, from string, perm ACL
 		headers: headers,
 		payload: nil,
 	}
-	fmt.Printf("REQ: %+v", req)
-	return b.S3.query(req, rsp)
+
+	return b.S3.rspquery(req, nil)
 }
 
 type RoutingRule struct {
@@ -668,6 +668,14 @@ func (s3 *S3) query(req *request, resp interface{}) error {
 		_, err = s3.run(req, resp)
 	}
 	return err
+}
+
+func (s3 *S3) rspquery(req *request, resp interface{}) (*http.Response, error) {
+	err := s3.prepare(req)
+	if err == nil {
+		return s3.run(req, resp)
+	}
+	return nil, err
 }
 
 // prepare sets up req to be delivered to S3.

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -317,7 +317,7 @@ func (b *Bucket) PutReader(path string, r io.Reader, length int64, contType stri
 	This function allows you to copy a file from one location to another.
 	The original source file will not be deleted.
 */
-func (b *Bucket) PutCopyFrom(path string, from string, perm ACL, options Options) (resp *http.Response, err error) {
+func (b *Bucket) PutCopyFrom(path string, from string, perm ACL, options Options) error {
 	headers := map[string][]string{
 		"x-amz-acl": {string(perm)},
 	}
@@ -339,7 +339,11 @@ func (b *Bucket) PutCopyFrom(path string, from string, perm ACL, options Options
 		payload: nil,
 	}
 
-	return b.S3.rspquery(req, nil)
+	resp, err := b.S3.rspquery(req, nil)
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	return err
 }
 
 type RoutingRule struct {

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -786,13 +786,9 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 	}
 
 	hresp, err := c.Do(&hreq)
+	defer hresp.Body.Close()
 
 	if err != nil {
-
-		if hresp.Body != nil {
-			hresp.Body.Close()
-		}
-
 		return nil, err
 	}
 	if debug {
@@ -808,11 +804,6 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 		if debug {
 			log.Printf("goamz.s3> decoded xml into %#v", resp)
 		}
-
-	}
-
-	if hresp.Body != nil {
-		hresp.Body.Close()
 	}
 
 	return hresp, err

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -313,11 +313,8 @@ func (b *Bucket) PutReader(path string, r io.Reader, length int64, contType stri
 	return b.S3.query(req, nil)
 }
 
-/*
-	This function allows you to copy a file from one location to another.
-	The original source file will not be deleted.
-*/
 func (b *Bucket) PutCopyFrom(path string, from string, perm ACL, options Options) (resp *http.Response, err error) {
+	fmt.Printf("%+v", path)
 	headers := map[string][]string{
 		"x-amz-acl": {string(perm)},
 	}
@@ -339,11 +336,7 @@ func (b *Bucket) PutCopyFrom(path string, from string, perm ACL, options Options
 		payload: nil,
 	}
 
-	err = b.S3.prepare(req)
-	if err == nil {
-		return b.S3.run(req, nil)
-	}
-	return nil, err
+	return b.S3.rspquery(req, nil)
 }
 
 type RoutingRule struct {
@@ -675,6 +668,14 @@ func (s3 *S3) query(req *request, resp interface{}) error {
 		_, err = s3.run(req, resp)
 	}
 	return err
+}
+
+func (s3 *S3) rspquery(req *request, resp interface{}) (*http.Response, error) {
+	err := s3.prepare(req)
+	if err == nil {
+		return s3.run(req, resp)
+	}
+	return nil, err
 }
 
 // prepare sets up req to be delivered to S3.

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -313,8 +313,11 @@ func (b *Bucket) PutReader(path string, r io.Reader, length int64, contType stri
 	return b.S3.query(req, nil)
 }
 
+/*
+	This function allows you to copy a file from one location to another.
+	The original source file will not be deleted.
+*/
 func (b *Bucket) PutCopyFrom(path string, from string, perm ACL, options Options) (resp *http.Response, err error) {
-	fmt.Printf("%+v", path)
 	headers := map[string][]string{
 		"x-amz-acl": {string(perm)},
 	}


### PR DESCRIPTION
This function allows you to copy a file from one location to another on S3. It is much faster than doing a Get/Put/Delete which is all that was originally available in the API. The original file will remain in tact so you'll need to do a Delete after the copy. 
