### PR TITLE
Fix HTTP Connections Leak

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -653,7 +653,7 @@ func (s3 *S3) query(req *request, resp interface{}) error {
 		return err
 	}
 	r, err := s3.run(req, resp)
-	if r.Body != nil {
+	if r != nil && r.Body != nil {
 		r.Body.Close()
 	}
 	return err

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -240,7 +240,9 @@ func (b *Bucket) Exists(path string) (exists bool, err error) {
 		if resp.StatusCode/100 == 2 {
 			exists = true
 		}
-		resp.Body.Close()
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
 		return exists, err
 	}
 	return false, fmt.Errorf("S3 Currently Unreachable")
@@ -651,7 +653,9 @@ func (s3 *S3) query(req *request, resp interface{}) error {
 		return err
 	}
 	r, err := s3.run(req, resp)
-	r.Body.Close()
+	if r.Body != nil {
+		r.Body.Close()
+	}
 	return err
 }
 

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -240,6 +240,7 @@ func (b *Bucket) Exists(path string) (exists bool, err error) {
 		if resp.StatusCode/100 == 2 {
 			exists = true
 		}
+		resp.Body.Close()
 		return exists, err
 	}
 	return false, fmt.Errorf("S3 Currently Unreachable")
@@ -646,9 +647,11 @@ func (req *request) url() (*url.URL, error) {
 // body will be unmarshalled on it.
 func (s3 *S3) query(req *request, resp interface{}) error {
 	err := s3.prepare(req)
-	if err == nil {
-		_, err = s3.run(req, resp)
+	if err != nil {
+		return err
 	}
+	r, err := s3.run(req, resp)
+	r.Body.Close()
 	return err
 }
 


### PR DESCRIPTION
The query() function ignores the http.Response that gets returned from run() function. If you make several requests to query() in a second, this will leave all the http connections open, causing a flood on the server of 'too many open files'. This fixes the leak. 
