### PR TITLE
Fix panic

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -236,7 +236,7 @@ func (b *Bucket) Exists(path string) (exists bool, err error) {
 
 		if err != nil {
 			// We can treat a 403 or 404 as non existance
-			if (*err.(*Error)).StatusCode == 403 || (*err.(*Error)).StatusCode == 404 {
+			if hasStatusCode(err, 403) || hasStatusCode(err, 404) {
 				return false, nil
 			} else {
 				return false, err
@@ -892,4 +892,9 @@ func shouldRetry(err error) bool {
 func hasCode(err error, code string) bool {
 	s3err, ok := err.(*Error)
 	return ok && s3err.Code == code
+}
+
+func hasStatusCode(err error, code int32) bool {
+	s3err, ok := err.(*Error)
+	return ok && s3err.StatusCode == code
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -894,7 +894,7 @@ func hasCode(err error, code string) bool {
 	return ok && s3err.Code == code
 }
 
-func hasStatusCode(err error, code int32) bool {
+func hasStatusCode(err error, code int) bool {
 	s3err, ok := err.(*Error)
 	return ok && s3err.StatusCode == code
 }


### PR DESCRIPTION
Attempt at fixing 
```2017-02-28 19:13:19 panic: interface conversion: error is *url.Error, not *s3.Error
2017-02-28 19:13:19
2017-02-28 19:13:19 goroutine 61 [running]:
2017-02-28 19:13:19	/var/lib/jenkins/jobs/h4b-reporting-service-33dceb31dc5e/workspace/.gosrc/src/github.com/hailocab/goamz/s3/s3.go:239 +0x2d8
2017-02-28 19:13:19 github.com/hailocab/h4b-reporting-service/dao.FileRepo.Exists(0xc82061ebe0, 0x12, 0x12, 0x0, 0x0)
2017-02-28 19:13:19 panic(0xd02300, 0xc8204f2000)
2017-02-28 19:13:19	/var/lib/jenkins/jobs/h4b-reporting-service-33dceb31dc5e/workspace/.gosrc/src/github.com/hailocab/h4b-reporting-service/dao/file_repo.go:47 +0x1b3
2017-02-28 19:13:19 github.com/hailocab/goamz/s3.(*Bucket).Exists(0xc8203f8760, 0xc82061ebe0, 0x12, 0xc82061eb00, 0x0, 0x0)
2017-02-28 19:13:19	/usr/local/go/versions/1.6.1/src/runtime/panic.go:464 +0x3e6
2017-02-28 19:13:19	<autogenerated>:11 +0xad
2017-02-28 19:13:19 github.com/hailocab/h4b-reporting-service/worker.GenerateStatements(0xecffa3d80, 0x0, 0x1327720, 0x0, 0x0, 0x0, 0x0, 0x0)
2017-02-28 19:13:19	/var/lib/jenkins/jobs/h4b-reporting-service-33dceb31dc5e/workspace/.gosrc/src/github.com/hailocab/h4b-reporting-service/worker/worker.go:213 +0x13ea
2017-02-28 19:13:19 github.com/hailocab/h4b-reporting-service/worker.Run()
2017-02-28 19:13:19	/var/lib/jenkins/jobs/h4b-reporting-service-33dceb31dc5e/workspace/.gosrc/src/github.com/hailocab/h4b-reporting-service/worker/worker.go:59 +0x2f0
2017-02-28 19:13:19 github.com/hailocab/h4b-reporting-service/dao.(*FileRepo).Exists(0x134b418, 0xc82061ebe0, 0x12, 0xe4b190, 0x0, 0x0)
2017-02-28 19:13:19	/var/lib/jenkins/jobs/h4b-reporting-service-33dceb31dc5e/workspace/.gosrc/src/github.com/hailocab/go-platform-layer/server/server.go:523 +0x4c8```
